### PR TITLE
feat(no-condition): add new rule to disallow arrow function as condition

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ if (a => 2) {
 };
 ```
 
-this is begger, because conditio of if is arrow function, not comparison.
+this is begger, because condition of if is arrow function, not comparison.
 this should be like this, and you can notice it's not you expect.
 
 ```js
@@ -70,6 +70,21 @@ var f = (a) => b ? c: d;
 
 you may notice what is this.
 
+### no-condition
+
+Disallow arrow function at place where condition is expected.
+
+The following patterns are considered warnings:
+
+```js
+if (a => 1) {}
+while (a => 1) {}
+for (var a = 1; a => 10; a++) {}
+a => 1 ? 2 : 3
+(a => 1) ? 2 : 3
+```
+
+Even if the arguments of arrow function is wrapped with parens, this rule warns it.
 
 ### space
 
@@ -104,6 +119,7 @@ plugins:
 rules:
   # Plugins
   arrow-function/parens : 2
+  arrow-function/no-condition : 2
   arrow-function/space  : 2
 ```
 

--- a/lib/rules/no-condition.js
+++ b/lib/rules/no-condition.js
@@ -1,0 +1,26 @@
+'use strict';
+
+var msg = 'suspicious code: it seemd to be comparison ">=", not arrow function "=>"';
+
+module.exports = function (context) {
+  function testProp(node) {
+    if (node.test.type === 'ArrowFunctionExpression') {
+      context.report(node, msg);
+    }
+  }
+
+  // for "a => 1 ? 2 : 3"
+  function arrowFunc(node) {
+    if (node.body.type === 'ConditionalExpression') {
+      context.report(node, msg);
+    }
+  }
+
+  return {
+    'IfStatement': testProp,
+    'WhileStatement': testProp,
+    'ForStatement': testProp,
+    'ConditionalExpression': testProp,
+    'ArrowFunctionExpression': arrowFunc
+  };
+};

--- a/tests/rules/no-condition.js
+++ b/tests/rules/no-condition.js
@@ -1,0 +1,42 @@
+'use strict';
+
+var linter = require('eslint').linter;
+var ESLintTester = require('eslint-tester');
+var eslintTester = new ESLintTester(linter);
+
+
+var valid = [
+  'if (a >= 1) {}',
+  'while (a >= 1) {}',
+  'for (var a = 1; a >= 10; a++) {}',
+  'a >= 1 ? 2 : 3',
+  '(a >= 1) ? 2 : 3',
+  '[1,2,3].filter(n => n > 2)'
+].map(function(code) {
+  return {
+    code: code,
+    ecmaFeatures: { arrowFunctions: true }
+  };
+});
+
+var message = 'suspicious code: it seemd to be comparison ">=", not arrow function "=>"';
+
+var invalid = [
+  'if (a => 1) {}',
+  'if ((a) => 1) {}',
+  'while (a => 1) {}',
+  'for (var a = 1; a => 10; a++) {}',
+  'a => 1 ? 2 : 3',
+  '(a => 1) ? 2 : 3'
+].map(function(code) {
+  return {
+    code: code,
+    ecmaFeatures: { arrowFunctions: true },
+    errors: [{ message: message }]
+  };
+});
+
+eslintTester.addRuleTest('./lib/rules/no-condition', {
+  valid: valid,
+  invalid: invalid
+});


### PR DESCRIPTION
This rule just disallows `if (a => 1) {}`.
