### PR TITLE
dont flag variable declarations

### DIFF
--- a/lib/rules/no-condition.js
+++ b/lib/rules/no-condition.js
@@ -11,7 +11,7 @@ module.exports = function(context) {
 
     // for "a => 1 ? 2 : 3"
     function arrowFunc(node) {
-        if (node.body.type === "ConditionalExpression") {
+        if (node.body.type === "ConditionalExpression" && node.parent.type !== "VariableDeclarator") {
             context.report(node, message);
         }
     }

--- a/tests/rules/no-condition.js
+++ b/tests/rules/no-condition.js
@@ -11,7 +11,8 @@ var valid = [
     "for (var a = 1; a >= 10; a++) {}",
     "a >= 1 ? 2 : 3",
     "(a >= 1) ? 2 : 3",
-    "[1,2,3].filter(n => n > 2)"
+    "[1,2,3].filter(n => n > 2)",
+    "var x = (val) => val ? true : false"
 ].map(function(code) {
     return {
         code: code,


### PR DESCRIPTION
I'm trying to use this plugin but also write arrow function expressions that look like this:

``` js
var x = a => a ? true : false
```

This PR allows that by not flagging nodes with a parent type of `VariableDeclarator`.
